### PR TITLE
Add Reputation & Rating System

### DIFF
--- a/contracts/escrow.clar
+++ b/contracts/escrow.clar
@@ -1,0 +1,22 @@
+(define-map escrow
+  { job_id: uint }
+  { client: principal, freelancer: principal, amount: uint, released: bool })
+
+(define-public (deposit-payment (job_id uint) (freelancer principal) (amount uint))
+  (begin
+    (asserts! (is-some (map-get? jobs { job_id: job_id })) (err u301))
+    (asserts! (is-none (map-get? escrow { job_id: job_id })) (err u302))
+    (map-set escrow { job_id: job_id } { client: tx-sender, freelancer: freelancer, amount: amount, released: false })
+    (ok "Payment deposited in escrow!")
+  ))
+
+(define-public (release-payment (job_id uint))
+  (begin
+    (let ((escrow-data (map-get? escrow { job_id: job_id })))
+      (match escrow-data
+        some (if (is-eq (get client escrow-data) tx-sender)
+                 (begin
+                   (map-set escrow { job_id: job_id } (merge escrow-data { released: true }))
+                   (ok "Payment released!"))
+                 (err u303))
+        none (err u304))))

--- a/contracts/job.clar
+++ b/contracts/job.clar
@@ -1,0 +1,21 @@
+(define-map jobs
+  { job_id: uint }
+  { client: principal, title: (buff 70), description: (buff 200), budget: uint, status: (buff 20) })
+
+(define-map bids
+  { job_id: uint, freelancer: principal }
+  { bid_amount: uint, proposal: (buff 150) })
+
+(define-public (post-job (job_id uint) (title (buff 70)) (description (buff 200)) (budget uint))
+  (begin
+    (asserts! (is-none (map-get? jobs { job_id: job_id })) (err u201))
+    (map-set jobs { job_id: job_id } { client: tx-sender, title: title, description: description, budget: budget, status: "open" })
+    (ok "Job posted successfully!")
+  ))
+
+(define-public (place-bid (job_id uint) (bid_amount uint) (proposal (buff 150)))
+  (begin
+    (asserts! (is-some (map-get? jobs { job_id: job_id })) (err u202))
+    (map-set bids { job_id: job_id, freelancer: tx-sender } { bid_amount: bid_amount, proposal: proposal })
+    (ok "Bid placed successfully!")
+  ))

--- a/contracts/reputation.clar
+++ b/contracts/reputation.clar
@@ -1,0 +1,19 @@
+(define-map ratings
+  { user: principal }
+  { total_ratings: uint, rating_sum: uint })
+
+(define-public (rate-user (user principal) (rating uint))
+  (begin
+    (asserts! (<= rating u5) (err u401))
+    (let ((existing (map-get? ratings { user: user })))
+      (match existing
+        some (map-set ratings { user: user } { total_ratings: (+ (get total_ratings existing) u1), rating_sum: (+ (get rating_sum existing) rating) })
+        none (map-set ratings { user: user } { total_ratings: u1, rating_sum: rating })))
+    (ok "Rating submitted!")
+  ))
+
+(define-read-only (get-user-rating (user principal))
+  (let ((data (map-get? ratings { user: user })))
+    (match data
+      some (ok (/ (get rating_sum data) (get total_ratings data)))
+      none (err u402))))


### PR DESCRIPTION
Implemented a rating system to allow freelancers and clients to rate each other.
Ratings are stored on-chain and calculated as an average score.
Helps maintain trust by allowing users to view reputation before engagement.